### PR TITLE
Fix wrong homepage

### DIFF
--- a/de.uni_heidelberg.zah.GaiaSky.metainfo.xml
+++ b/de.uni_heidelberg.zah.GaiaSky.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>de.uni_heidelberg.zah.GaiaSky</id>
-  <url type="homepage">https://zah.uni-heidelberg.de/institutes/ari/gaia/outreach/gaiasky/</url>
+  <url type="homepage">https://zah.uni-heidelberg.de/gaia/outreach/gaiasky</url>
   <url type="help">https://gaia.ari.uni-heidelberg.de/gaiasky/docs/html/latest/</url>
   <url type="bugtracker">https://gitlab.com/langurmonkey/gaiasky/-/issues</url>
   


### PR DESCRIPTION
The website referenced before was incorrect and redirected to a webpage with 404 error code.