### PR TITLE
Version 3.2.0

### DIFF
--- a/de.uni_heidelberg.zah.GaiaSky.metainfo.xml
+++ b/de.uni_heidelberg.zah.GaiaSky.metainfo.xml
@@ -4,30 +4,30 @@
   <url type="homepage">https://zah.uni-heidelberg.de/gaia/outreach/gaiasky/</url>
   <url type="help">https://gaia.ari.uni-heidelberg.de/gaiasky/docs</url>
   <url type="bugtracker">https://gitlab.com/langurmonkey/gaiasky/-/issues</url>
-  
+
   <name>Gaia Sky</name>
   <summary>Open Source 3D universe simulator for desktop and VR with support for more than a billion objects</summary>
-  
+
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   <developer_name>ARI/Zentrum für Astronomie Heidelberg</developer_name>
-  
+
   <recommends>
     <control>pointing</control>
     <control>keyboard</control>
     <control>gamepad</control>
   </recommends>
-  
+
   <description>
     <p>
       Gaia Sky is a real-time, 3D, astronomy visualisation software for desktop and VR that runs on Linux, Windows and macOS. It is developed in the framework of ESA&apos;s Gaia mission to chart about 1 billion stars of our Galaxy in the Gaia group of the Astronomisches Rechen-Institut (ZAH, Universität Heidelberg). Explore the Solar System, the Milky Way or even the most distant galaxies of the Universe.
     </p>
   </description>
-  
-   <releases>
-      <release version="3.1.6" date="2021-09-22" urgency="high">
-        <url>https://gitlab.com/langurmonkey/gaiasky/blob/master/CHANGELOG.md</url>
-      </release>
+
+  <releases>
+    <release version="3.2.0" date="2022-06-07" urgency="high">
+      <url>https://gaia.ari.uni-heidelberg.de/gaiasky/files/releases/3.2.0.84c0fc728/releasenotes.html</url>
+    </release>
   </releases>
 
   <content_rating type="oars-1.1" />

--- a/de.uni_heidelberg.zah.GaiaSky.yaml
+++ b/de.uni_heidelberg.zah.GaiaSky.yaml
@@ -35,8 +35,8 @@ modules:
        - install -D de.uni_heidelberg.zah.GaiaSky.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
     sources:
       - type: archive
-        url: https://gaia.ari.uni-heidelberg.de/gaiasky/files/releases/latest/gaiasky-3.1.6.986c7b5ee.tar.gz
-        sha256: de069b89300721f4450e4d75aa978895fd3159d732624e3de7d350b8810723a2
+        url: https://gaia.ari.uni-heidelberg.de/gaiasky/files/releases/latest/gaiasky-3.2.0.84c0fc728.tar.gz
+        sha256: 482206a79b06cbe44a5228b8f9c4c5b64da4eaed92434112f737b33a3825e60d
       - type: file
         path: de.uni_heidelberg.zah.GaiaSky.desktop
       - type: file


### PR DESCRIPTION
Update Gaia Sky flatpak to version 3.2.0. All works fine locally.