### PR TITLE
Enable controllers with device=all.

### DIFF
--- a/de.uni_heidelberg.zah.GaiaSky.yaml
+++ b/de.uni_heidelberg.zah.GaiaSky.yaml
@@ -6,7 +6,7 @@ sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk]
 command: gaiasky
 finish-args:
   - --socket=x11
-  - --device=dri
+  - --device=all
   - --socket=pulseaudio
   - --share=ipc
   - --share=network


### PR DESCRIPTION
This commit enables SDL controllers, which do not currently work in the flatpak version. For instance, the Gaia Sky is super easy to install on the Steam Deck thanks to flatpak/flathub, but the Deck controller is not being detected. In this case, Gaia Sky can only be used with the Steam Deck controller in desktop emulation mode. This should fix the problem.