### PR TITLE
Version 3.6.2-3

### DIFF
--- a/de.uni_heidelberg.zah.GaiaSky.metainfo.xml
+++ b/de.uni_heidelberg.zah.GaiaSky.metainfo.xml
@@ -26,8 +26,8 @@
 
   <releases>
 
-    <release version="3.6.2-2" date="2024-06-06" urgency="high">
-      <url>https://gaia.ari.uni-heidelberg.de/gaiasky/releases/3.6.2-2.c12559806/releasenotes.html</url>
+    <release version="3.6.2-3" date="2024-06-07" urgency="high">
+      <url>https://gaia.ari.uni-heidelberg.de/gaiasky/releases/3.6.2-3.d5632974f/releasenotes.html</url>
       <description>
         <p>New features and bug fixes:</p>
         <ul>
@@ -38,6 +38,7 @@
           <li>enable ray-marching effects in cubemap and stereoscopic mode.</li>
           <li>restore light glow effect in cubemap and stereoscopic modes.</li>
           <li>fix regression on some graphics drivers where the app crashed compiling a shader.</li>
+          <li>fix SVT indirection shader cleared with wrong value.</li>
           </ul>
         </description>
       </release>

--- a/de.uni_heidelberg.zah.GaiaSky.yaml
+++ b/de.uni_heidelberg.zah.GaiaSky.yaml
@@ -39,8 +39,8 @@ modules:
        - install -D de.uni_heidelberg.zah.GaiaSky.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
     sources:
       - type: archive
-        url: https://gaia.ari.uni-heidelberg.de/gaiasky/releases/3.6.2-2.c12559806/gaiasky-3.6.2-2.c12559806.tar.gz
-        sha256: dd8e953eaf5bf00e31b054a96287d345650ac4f7514b56eb77dd3aa8e72fd475
+        url: https://gaia.ari.uni-heidelberg.de/gaiasky/releases/3.6.2-3.d5632974f/gaiasky-3.6.2-3.d5632974f.tar.gz
+        sha256: 3227a4f67253c52c0937c104d6ac8cea78e2961d1f63a333c2d23ca7df6ff9fb
       - type: file
         path: de.uni_heidelberg.zah.GaiaSky.desktop
       - type: file


### PR DESCRIPTION
See https://gaia.ari.uni-heidelberg.de/gaiasky/releases/3.6.2-3.d5632974f/releasenotes.html.